### PR TITLE
Change strife to strafe

### DIFF
--- a/src/Camera.elm
+++ b/src/Camera.elm
@@ -20,8 +20,8 @@ import Math.Vector3 as Vec3 exposing (Vec3, vec3)
 type Movement
     = TurnLeft
     | TurnRight
-    | StrifeLeft
-    | StrifeRight
+    | StrafeLeft
+    | StrafeRight
     | LookUp
     | LookDown
     | WalkForward
@@ -105,12 +105,12 @@ update dt movement ({ direction, xAngle, zAngle } as camera) =
 
         xDirection =
             case movement of
-                StrifeLeft ->
+                StrafeLeft ->
                     Vec3.cross newDirection Vec3.k
                         |> Vec3.normalize
                         |> Vec3.scale -speed
 
-                StrifeRight ->
+                StrafeRight ->
                     Vec3.cross newDirection Vec3.k
                         |> Vec3.normalize
                         |> Vec3.scale speed

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -384,7 +384,7 @@ view model =
 
 readyMessage =
     [ ( "Arrows", " Walk/turn" )
-    , ( "Alt+Arrows", " Strife" )
+    , ( "Alt+Arrows", " Strafe" )
     , ( "A", " Look up" )
     , ( "Z", " Look down" )
 
@@ -596,10 +596,10 @@ movement on altOn keyCode =
             LookDown
 
         ( True, 37, True ) ->
-            StrifeLeft
+            StrafeLeft
 
         ( True, 39, True ) ->
-            StrifeRight
+            StrafeRight
 
         _ ->
             Idle


### PR DESCRIPTION
The word is actually "strafe" and not "strife". It's a strange non-standard English word that only has this meaning in the FPS genre of video games. https://english.stackexchange.com/questions/434252/origin-of-strafe-meaning-move-sideways

The more common alternative would simply be "move sideways" but definitely not "strife". :)

Amazing work btw!